### PR TITLE
新增 migrate SQL 文件

### DIFF
--- a/migrate/2.0.0/migrate.sql
+++ b/migrate/2.0.0/migrate.sql
@@ -1,0 +1,42 @@
+-- ----------------------------
+-- 2.0.0 DB 迁移 SQL
+-- ----------------------------
+
+
+-- ----------------------------
+-- status 服务
+-- ----------------------------
+
+-- status 点赞表
+CREATE TABLE `user2status` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`user_id` int(11) DEFAULT NULL,
+	`status_id` int(11) DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	KEY `user_id` (`user_id`),
+	KEY `status_id` (`status_id`),
+	UNIQUE KEY `user_status` (`user_id`,`status_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+
+-- ----------------------------
+-- user 服务
+-- ----------------------------
+
+-- token 黑名单
+DROP TABLE IF EXISTS `blacklist`;
+CREATE TABLE `blacklist` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `token` varchar(255) DEFAULT "" NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `expires_at` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_token` (`token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
+
+
+-- ----------------------------
+-- project 服务
+-- ----------------------------
+
+-- project 文件存储重构


### PR DESCRIPTION
因为涉及线上 DB 结构的改动，需要把每个版本的 DB 结构升级写到文件中记录，这样方便管理。创建了 2.0.0（重构之后的新版本）的 SQL 文件。后续的表结构改动都需要写到这里。注意，这个 SQL 是可执行的，就是到时候在生产 DB  上执行的那个 SQL。所以需要包括数据迁移，表结构 Alter，新表 Create 等等各种涉及 DB 的操作。